### PR TITLE
Add H2 storage option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compileOnly 'net.milkbowl.vault:VaultAPI:1.7'
     compileOnly 'com.github.leaderos-net:leaderos-plugin:1.1.0'
     compileOnly 'mysql:mysql-connector-java:8.0.33'
+    compileOnly 'com.h2database:h2:2.2.224'
 }
 
 jar {

--- a/config.yml
+++ b/config.yml
@@ -1,11 +1,15 @@
 # Configuración del plugin Servidirectorios
 
 database:
-  host: 'localhost'
-  port: '3306'
-  database: 'servidirectorios_db'
-  username: 'usuario'
-  password: 'contraseña'
+  # Tipo de almacenamiento: 'h2' o 'mysql'
+  type: 'h2'
+  file: 'database'
+  mysql:
+    host: 'localhost'
+    port: '3306'
+    database: 'servidirectorios_db'
+    username: 'usuario'
+    password: 'contraseña'
 
 credit-slots-stay-on-page-switch: true
 

--- a/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
+++ b/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
@@ -2,6 +2,7 @@ package org.servicraft.servidirectorios.database;
 
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import java.io.File;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -21,19 +22,35 @@ public class DatabaseManager {
 
     public static void init(JavaPlugin plugin) {
         FileConfiguration config = plugin.getConfig();
-        String host = config.getString("database.host");
-        String port = config.getString("database.port");
-        String db = config.getString("database.database");
-        String user = config.getString("database.username");
-        String pass = config.getString("database.password");
-
-        String url = "jdbc:mysql://" + host + ":" + port + "/" + db + "?useSSL=false&autoReconnect=true";
-        try {
-            connection = DriverManager.getConnection(url, user, pass);
-            createTables();
-        } catch (SQLException e) {
-            e.printStackTrace();
-            connection = null;
+        String type = config.getString("database.type", "h2");
+        if (type.equalsIgnoreCase("mysql")) {
+            String host = config.getString("database.mysql.host");
+            String port = config.getString("database.mysql.port");
+            String db = config.getString("database.mysql.database");
+            String user = config.getString("database.mysql.username");
+            String pass = config.getString("database.mysql.password");
+            String url = "jdbc:mysql://" + host + ":" + port + "/" + db + "?useSSL=false&autoReconnect=true";
+            try {
+                connection = DriverManager.getConnection(url, user, pass);
+                createTables();
+            } catch (SQLException e) {
+                e.printStackTrace();
+                connection = null;
+            }
+        } else {
+            String fileName = config.getString("database.file", "database");
+            File dataFolder = plugin.getDataFolder();
+            if (!dataFolder.exists()) {
+                dataFolder.mkdirs();
+            }
+            String url = "jdbc:h2:" + new File(dataFolder, fileName).getPath();
+            try {
+                connection = DriverManager.getConnection(url, "sa", "");
+                createTables();
+            } catch (SQLException e) {
+                e.printStackTrace();
+                connection = null;
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,16 @@
 # Configuración del plugin Servidirectorios
 
 database:
-  host: 'localhost'
-  port: '3306'
-  database: 'servidirectorios_db'
-  username: 'usuario'
-  password: 'contraseña'
+  # Tipo de almacenamiento: 'h2' o 'mysql'
+  type: 'h2'
+  # Archivo para la base de datos H2 (relativo a la carpeta de datos del plugin)
+  file: 'database'
+  mysql:
+    host: 'localhost'
+    port: '3306'
+    database: 'servidirectorios_db'
+    username: 'usuario'
+    password: 'contraseña'
 
 credit-slots-stay-on-page-switch: true
 


### PR DESCRIPTION
## Summary
- let config select between MySQL and new H2 storage
- default to H2 in sample configs
- add H2 JDBC driver dependency

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6840a3758168832fb7fcaf1642111c97