### PR TITLE
Fix H2 driver and update GUI layout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 group 'org.servicraft'
@@ -39,9 +40,14 @@ dependencies {
     compileOnly 'net.milkbowl.vault:VaultAPI:1.7'
     compileOnly 'com.github.leaderos-net:leaderos-plugin:1.1.0'
     compileOnly 'mysql:mysql-connector-java:8.0.33'
-    compileOnly 'com.h2database:h2:2.2.224'
+    implementation 'com.h2database:h2:2.2.224'
 }
 
 jar {
     // No se incluyen las dependencias compileOnly en el JAR.
+}
+
+shadowJar {
+    // El JAR final incluirá las dependencias necesarias, sin clasificador extra
+    archiveClassifier.set('')
 }

--- a/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
+++ b/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
@@ -45,9 +45,11 @@ public class DatabaseManager {
             }
             String url = "jdbc:h2:" + new File(dataFolder, fileName).getPath();
             try {
+                // Cargar el driver manualmente para evitar problemas de "No suitable driver"
+                Class.forName("org.h2.Driver");
                 connection = DriverManager.getConnection(url, "sa", "");
                 createTables();
-            } catch (SQLException e) {
+            } catch (ClassNotFoundException | SQLException e) {
                 e.printStackTrace();
                 connection = null;
             }

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
@@ -17,7 +17,7 @@ public class BuySlotGUI {
 
     public static void open(Player player, int page) {
         playerPages.put(player.getUniqueId(), page);
-        Inventory inv = Bukkit.createInventory(null, 54, "Puestos promocionados - Página " + page);
+        Inventory inv = Bukkit.createInventory(null, 27, "Puestos promocionados - Página " + page);
 
         // Rango de puestos para cada tipo de moneda
         org.bukkit.plugin.java.JavaPlugin plugin =
@@ -32,7 +32,7 @@ public class BuySlotGUI {
 
         int servSlotsPerPage = servEnd - servStart + 1;
 
-        for (int slot = 0; slot < inv.getSize(); slot++) {
+        for (int slot = 0; slot < 26; slot++) {
             boolean isCredit = slot >= creditStart && slot <= creditEnd;
             boolean isServDisplay = slot >= servStart && slot <= servEnd;
             if (!isCredit && !isServDisplay) continue;
@@ -44,8 +44,13 @@ public class BuySlotGUI {
             double price = cfg.getDouble("slot-prices." + priceIndex, 0.0);
             boolean ocupado = isCredit && (slot == creditStart || slot == creditStart + 1);
 
+            int displayNumber = slot + 1;
+            if (isServDisplay && page > 1) {
+                displayNumber = slot + servSlotsPerPage * (page - 1) + 1;
+            }
+
             Material mat = ocupado ? Material.RED_STAINED_GLASS_PANE : Material.LIME_STAINED_GLASS_PANE;
-            String nombre = (ocupado ? ChatColor.RED : ChatColor.GREEN) + "Puesto " + (slot + 1);
+            String nombre = (ocupado ? ChatColor.RED : ChatColor.GREEN) + "Puesto " + displayNumber;
 
             List<String> lore = new ArrayList<>();
             if (ocupado) {
@@ -68,10 +73,16 @@ public class BuySlotGUI {
             inv.setItem(slot, buildItem(mat, nombre, lore));
         }
 
-        // Pagination: posición [6,9] → índice 53
-        inv.setItem(53, buildItem(Material.MAGENTA_GLAZED_TERRACOTTA,
-                ChatColor.LIGHT_PURPLE + "Haz clic para ver más puestos (todos en servidólares)",
-                null));
+        // Paginación: siguiente o anterior página
+        if (page <= 1) {
+            inv.setItem(26, buildItem(Material.MAGENTA_GLAZED_TERRACOTTA,
+                    ChatColor.WHITE + "Siguiente página",
+                    null));
+        } else {
+            inv.setItem(18, buildItem(Material.MAGENTA_GLAZED_TERRACOTTA,
+                    ChatColor.WHITE + "Página anterior",
+                    null));
+        }
 
         // Llenar espacios vacíos con panel de vidrio verde
         fillEmptySlots(inv, Material.LIME_STAINED_GLASS_PANE, ChatColor.GREEN + " ");

--- a/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
@@ -16,7 +16,7 @@ public class ShortcutMenu {
 
     public static void open(Player player) {
         List<Shortcut> shortcuts = DatabaseManager.getShortcuts();
-        Inventory inv = Bukkit.createInventory(null, 54, "Directorios");
+        Inventory inv = Bukkit.createInventory(null, 27, "Directorios");
 
         int index = 0;
         for (Shortcut sc : shortcuts) {

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
@@ -34,9 +34,15 @@ public class BuySlotGUIListener implements Listener {
             // Si se hace clic en el botón de paginación (azulejo magenta)
             if (clickedItem.getType() == Material.MAGENTA_GLAZED_TERRACOTTA) {
                 int currentPage = BuySlotGUI.getCurrentPage(player);
-                int nextPage = currentPage + 1;
-                player.sendMessage(ChatColor.AQUA + "Cambiando a la página " + nextPage + " de puestos promocionados...");
-                BuySlotGUI.open(player, nextPage);
+                if (displayName.contains("Siguiente página")) {
+                    int nextPage = currentPage + 1;
+                    player.sendMessage(ChatColor.AQUA + "Cambiando a la página " + nextPage + " de puestos promocionados...");
+                    BuySlotGUI.open(player, nextPage);
+                } else if (displayName.contains("Página anterior")) {
+                    int prevPage = Math.max(1, currentPage - 1);
+                    player.sendMessage(ChatColor.AQUA + "Volviendo a la página " + prevPage + " de puestos promocionados...");
+                    BuySlotGUI.open(player, prevPage);
+                }
                 return;
             }
             


### PR DESCRIPTION
## Summary
- load the H2 driver before opening the database
- include H2 in the shaded jar
- shrink GUI menus to single chest (27 slots)
- adjust pagination buttons and numbering
- handle previous/next page clicks properly

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6841c36adeec832fa91d758ba4a1c104