### PR TITLE
Add duration selection GUI for slot purchases

### DIFF
--- a/src/main/java/org/servicraft/servidirectorios/Servidirectorios.java
+++ b/src/main/java/org/servicraft/servidirectorios/Servidirectorios.java
@@ -5,6 +5,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.servicraft.servidirectorios.commands.DirectoriosCommand;
 import org.servicraft.servidirectorios.commands.CreateShortcutCommand;
 import org.servicraft.servidirectorios.listeners.BuySlotGUIListener;
+import org.servicraft.servidirectorios.listeners.BuySlotWeeksGUIListener;
 import org.servicraft.servidirectorios.listeners.ShortcutMenuListener;
 import org.servicraft.servidirectorios.database.DatabaseManager;
 import net.milkbowl.vault.economy.Economy;
@@ -35,6 +36,7 @@ public class Servidirectorios extends JavaPlugin {
         
         // Registrar listeners para las GUIs
         getServer().getPluginManager().registerEvents(new BuySlotGUIListener(), this);
+        getServer().getPluginManager().registerEvents(new BuySlotWeeksGUIListener(), this);
         getServer().getPluginManager().registerEvents(new ShortcutMenuListener(), this);
     }
     

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
@@ -1,0 +1,114 @@
+package org.servicraft.servidirectorios.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.text.NumberFormat;
+import java.util.*;
+
+public class BuySlotWeeksGUI {
+
+    private static final Map<UUID, Integer> playerWeeks = new HashMap<>();
+    private static final Map<UUID, Double> playerPrice = new HashMap<>();
+    private static final Map<UUID, Boolean> playerCredit = new HashMap<>();
+
+    public static void open(Player player, double price, boolean credit) {
+        playerWeeks.put(player.getUniqueId(), 1);
+        playerPrice.put(player.getUniqueId(), price);
+        playerCredit.put(player.getUniqueId(), credit);
+
+        Inventory inv = Bukkit.createInventory(null, 27, "Comprar puesto");
+        inv.setItem(10, buildItem(Material.IRON_NUGGET, ChatColor.RED + "Reducir 1 semana", null));
+        inv.setItem(12, buildPayItem(player));
+        inv.setItem(14, buildItem(Material.GOLD_NUGGET, ChatColor.GREEN + "Incrementar una semana", null));
+
+        fillEmptySlots(inv, Material.BLACK_STAINED_GLASS_PANE, " ");
+
+        player.openInventory(inv);
+    }
+
+    private static ItemStack buildItem(Material material, String displayName, List<String> lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(displayName);
+            if (lore != null) meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void fillEmptySlots(Inventory inv, Material material, String displayName) {
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) == null) {
+                ItemStack item = new ItemStack(material);
+                ItemMeta meta = item.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(displayName);
+                    item.setItemMeta(meta);
+                }
+                inv.setItem(i, item);
+            }
+        }
+    }
+
+    private static ItemStack buildPayItem(Player player) {
+        int weeks = playerWeeks.getOrDefault(player.getUniqueId(), 1);
+        double price = playerPrice.getOrDefault(player.getUniqueId(), 0.0);
+        boolean credit = playerCredit.getOrDefault(player.getUniqueId(), false);
+        double total = price * weeks;
+
+        ItemStack item = new ItemStack(Material.EMERALD);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GREEN + "Pagar");
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Resumen del pedido:");
+            lore.add(" ");
+            lore.add(ChatColor.GRAY + String.valueOf(weeks) + " semanas");
+            if (credit) {
+                String formatted = String.format(Locale.US, "%.2f", total).replace('.', ',');
+                lore.add(ChatColor.AQUA + formatted + " créditos");
+            } else {
+                String formatted = NumberFormat.getInstance(Locale.GERMAN).format(total);
+                lore.add(ChatColor.GREEN + "$" + formatted + ChatColor.GREEN + " servi" + ChatColor.DARK_GREEN + "dólares");
+            }
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public static void incrementWeeks(Player player, Inventory inv) {
+        int weeks = playerWeeks.getOrDefault(player.getUniqueId(), 1);
+        weeks++;
+        playerWeeks.put(player.getUniqueId(), weeks);
+        inv.setItem(12, buildPayItem(player));
+    }
+
+    public static void decrementWeeks(Player player, Inventory inv) {
+        int weeks = playerWeeks.getOrDefault(player.getUniqueId(), 1);
+        if (weeks > 1) {
+            weeks--;
+            playerWeeks.put(player.getUniqueId(), weeks);
+            inv.setItem(12, buildPayItem(player));
+        }
+    }
+
+    public static int getWeeks(Player player) {
+        return playerWeeks.getOrDefault(player.getUniqueId(), 1);
+    }
+
+    public static double getPrice(Player player) {
+        return playerPrice.getOrDefault(player.getUniqueId(), 0.0);
+    }
+
+    public static boolean isCredit(Player player) {
+        return playerCredit.getOrDefault(player.getUniqueId(), false);
+    }
+}

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
@@ -1,6 +1,5 @@
 package org.servicraft.servidirectorios.listeners;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -9,9 +8,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.servicraft.servidirectorios.Servidirectorios;
 import org.servicraft.servidirectorios.gui.BuySlotGUI;
-import net.milkbowl.vault.economy.Economy;
+import org.servicraft.servidirectorios.gui.BuySlotWeeksGUI;
 
 public class BuySlotGUIListener implements Listener {
 
@@ -42,75 +40,26 @@ public class BuySlotGUIListener implements Listener {
             
             // Procesar la compra si el item posee la acción de compra (se busca la línea "Haz clic para comprar este puesto!")
             if (displayName.contains("¡Disponible!") || (meta.hasLore() && meta.getLore().stream().anyMatch(line -> line.contains("Haz clic para comprar este puesto!")))) {
-                // Determinar la fila (1-based) del item a partir del slot
                 int slot = event.getRawSlot();
                 int row = (slot / 9) + 1;
-                
-                // Obtener el costo desde la lore; se asume que la línea de costo es la segunda línea
-                String costLine = "";
-                if (meta.hasLore() && meta.getLore().size() > 1) {
-                    costLine = meta.getLore().get(1);
+
+                org.bukkit.configuration.file.FileConfiguration cfg = org.bukkit.plugin.java.JavaPlugin.getPlugin(org.servicraft.servidirectorios.Servidirectorios.class).getConfig();
+                int creditStart = cfg.getInt("credit-slots.start");
+                int creditEnd = cfg.getInt("credit-slots.end");
+                int servStart = cfg.getInt("servidolar-slots.start");
+                int servEnd = cfg.getInt("servidolar-slots.end");
+
+                int priceIndex = slot;
+                int page = BuySlotGUI.getCurrentPage(player);
+                int servSlotsPerPage = servEnd - servStart + 1;
+                if (slot >= servStart && slot <= servEnd && page > 1) {
+                    priceIndex = slot + servSlotsPerPage * (page - 1);
                 }
-                // Se espera un formato: "Costo semanal: X créditos" o "Costo semanal: X servidólares"
-                double cost = 0;
-                try {
-                    String[] parts = costLine.split(":");
-                    if (parts.length >= 2) {
-                        String costPart = parts[1].trim().split(" ")[0];
-                        costPart = costPart.replace(",", "."); // Asegurar formato decimal
-                        cost = Double.parseDouble(costPart);
-                    }
-                } catch (NumberFormatException ex) {
-                    player.sendMessage(ChatColor.RED + "Error al procesar el costo del puesto.");
-                    return;
-                }
-                
-                // Procesar el pago según el sistema de moneda
-                if (row == 1) {
-                    // Pago con créditos utilizando LeaderOS
-                    player.sendMessage(ChatColor.GREEN + "Procesando compra con créditos...");
-                    final Player targetPlayer = player;
-                    final double transactionCost = cost;
-                    Bukkit.getScheduler().runTaskAsynchronously(Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> {
-                        boolean success;
-                        try {
-                            // Se quitan créditos directamente utilizando la API de LeaderOS
-                            success = net.leaderos.plugin.api.LeaderOSAPI.getCreditManager().remove(targetPlayer.getName(), transactionCost);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                            success = false;
-                        }
-                        if (success) {
-                            Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> {
-                                // Aquí se debe actualizar el estado del puesto en MySQL y actualizar la GUI (cambiar a estado ocupado)
-                                targetPlayer.sendMessage(ChatColor.GREEN + "Compra exitosa. Se te han descontado " + transactionCost + " créditos.");
-                            });
-                        } else {
-                            Bukkit.getScheduler().runTask(Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> {
-                                targetPlayer.sendMessage(ChatColor.RED + "No tienes suficientes créditos o ocurrió un error.");
-                            });
-                        }
-                    });
-                } else if (row == 2 || row == 3) {
-                    // Pago con servidólares utilizando Vault
-                    player.sendMessage(ChatColor.GREEN + "Procesando compra con servidólares...");
-                    Economy economy = Servidirectorios.getEconomy();
-                    if (economy == null) {
-                        player.sendMessage(ChatColor.RED + "El sistema de economía no está disponible.");
-                        return;
-                    }
-                    if (economy.getBalance(player) >= cost) {
-                        net.milkbowl.vault.economy.EconomyResponse response = economy.withdrawPlayer(player, cost);
-                        if (response.transactionSuccess()) {
-                            // Actualizar el estado del puesto en MySQL (placeholder) y la GUI
-                            player.sendMessage(ChatColor.GREEN + "Compra exitosa. Se te han descontado " + cost + " servidólares.");
-                        } else {
-                            player.sendMessage(ChatColor.RED + "No se pudo completar la transacción.");
-                        }
-                    } else {
-                        player.sendMessage(ChatColor.RED + "No tienes suficientes servidólares.");
-                    }
-                }
+
+                double cost = cfg.getDouble("slot-prices." + priceIndex, 0.0);
+                boolean credit = slot >= creditStart && slot <= creditEnd;
+
+                BuySlotWeeksGUI.open(player, cost, credit);
             }
         }
     }

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
@@ -1,0 +1,76 @@
+package org.servicraft.servidirectorios.listeners;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.servicraft.servidirectorios.Servidirectorios;
+import org.servicraft.servidirectorios.gui.BuySlotWeeksGUI;
+import net.milkbowl.vault.economy.Economy;
+
+public class BuySlotWeeksGUIListener implements Listener {
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals("Comprar puesto")) {
+            return;
+        }
+        event.setCancelled(true);
+        ItemStack item = event.getCurrentItem();
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        Inventory inv = event.getInventory();
+        int slot = event.getRawSlot();
+        if (slot == 10) {
+            BuySlotWeeksGUI.decrementWeeks(player, inv);
+        } else if (slot == 14) {
+            BuySlotWeeksGUI.incrementWeeks(player, inv);
+        } else if (slot == 12) {
+            int weeks = BuySlotWeeksGUI.getWeeks(player);
+            double price = BuySlotWeeksGUI.getPrice(player) * weeks;
+            boolean credit = BuySlotWeeksGUI.isCredit(player);
+            if (credit) {
+                player.sendMessage(ChatColor.GREEN + "Procesando compra con créditos...");
+                final Player target = player;
+                final double amount = price;
+                org.bukkit.Bukkit.getScheduler().runTaskAsynchronously(org.bukkit.Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> {
+                    boolean success;
+                    try {
+                        success = net.leaderos.plugin.api.LeaderOSAPI.getCreditManager().remove(target.getName(), amount);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        success = false;
+                    }
+                    if (success) {
+                        org.bukkit.Bukkit.getScheduler().runTask(org.bukkit.Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> target.sendMessage(ChatColor.GREEN + "Compra exitosa."));
+                    } else {
+                        org.bukkit.Bukkit.getScheduler().runTask(org.bukkit.Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> target.sendMessage(ChatColor.RED + "No tienes suficientes créditos o ocurrió un error."));
+                    }
+                });
+            } else {
+                Economy econ = Servidirectorios.getEconomy();
+                if (econ == null) {
+                    player.sendMessage(ChatColor.RED + "El sistema de economía no está disponible.");
+                    return;
+                }
+                if (econ.getBalance(player) >= price) {
+                    net.milkbowl.vault.economy.EconomyResponse resp = econ.withdrawPlayer(player, price);
+                    if (resp.transactionSuccess()) {
+                        player.sendMessage(ChatColor.GREEN + "Compra exitosa.");
+                    } else {
+                        player.sendMessage(ChatColor.RED + "No se pudo completar la transacción.");
+                    }
+                } else {
+                    player.sendMessage(ChatColor.RED + "No tienes suficientes servidólares.");
+                }
+            }
+            player.closeInventory();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new BuySlotWeeksGUI for choosing weeks and calculating price
- add BuySlotWeeksGUIListener to handle increment, decrement, and payment
- open the new menu from BuySlotGUIListener when clicking an available slot
- register the new listener in the plugin

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6841c5300d70832f86b730e5e2c05877