### PR TITLE
Fix slot purchase persistence

### DIFF
--- a/src/main/java/org/servicraft/servidirectorios/Servidirectorios.java
+++ b/src/main/java/org/servicraft/servidirectorios/Servidirectorios.java
@@ -29,6 +29,7 @@ public class Servidirectorios extends JavaPlugin {
 
         // Inicializar base de datos
         DatabaseManager.init(this);
+        DatabaseManager.cleanupExpiredSlotsPublic();
 
         // Registrar comandos
         this.getCommand("directorios").setExecutor(new DirectoriosCommand(this));

--- a/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
+++ b/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
@@ -9,6 +9,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,7 +44,8 @@ public class DatabaseManager {
             if (!dataFolder.exists()) {
                 dataFolder.mkdirs();
             }
-            String url = "jdbc:h2:" + new File(dataFolder, fileName).getPath();
+            // Use absolute path to satisfy H2 requirement for explicit file locations
+            String url = "jdbc:h2:" + new File(dataFolder, fileName).getAbsolutePath();
             try {
                 // Cargar el driver manualmente para evitar problemas de "No suitable driver"
                 Class.forName("org.h2.Driver");
@@ -69,7 +71,13 @@ public class DatabaseManager {
                 "yaw FLOAT NOT NULL," +
                 "pitch FLOAT NOT NULL" +
                 ")";
+        String slots = "CREATE TABLE IF NOT EXISTS slots (" +
+                "slot_index INT PRIMARY KEY," +
+                "shortcut_id INT NOT NULL," +
+                "expires BIGINT NOT NULL" +
+                ")";
         connection.createStatement().executeUpdate(shortcuts);
+        connection.createStatement().executeUpdate(slots);
     }
 
     public static boolean isConnected() {
@@ -98,10 +106,10 @@ public class DatabaseManager {
         return list;
     }
 
-    public static void createShortcut(String name, String description, Location loc) {
-        if (connection == null) return;
+    public static int createShortcut(String name, String description, Location loc) {
+        if (connection == null) return -1;
         String sql = "INSERT INTO shortcuts(name, description, world, x, y, z, yaw, pitch) VALUES(?,?,?,?,?,?,?,?)";
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, name);
             ps.setString(2, description);
             ps.setString(3, loc.getWorld().getName());
@@ -111,8 +119,102 @@ public class DatabaseManager {
             ps.setFloat(7, loc.getYaw());
             ps.setFloat(8, loc.getPitch());
             ps.executeUpdate();
+            ResultSet rs = ps.getGeneratedKeys();
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
+        return -1;
+    }
+
+    private static void cleanExpiredSlots() {
+        if (connection == null) return;
+        String sql = "DELETE FROM slots WHERE expires <= ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, System.currentTimeMillis());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void cleanupExpiredSlotsPublic() {
+        cleanExpiredSlots();
+    }
+
+    public static boolean isSlotOccupied(int slotIndex) {
+        cleanExpiredSlots();
+        if (connection == null) return false;
+        String sql = "SELECT 1 FROM slots WHERE slot_index = ? AND expires > ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, slotIndex);
+            ps.setLong(2, System.currentTimeMillis());
+            ResultSet rs = ps.executeQuery();
+            return rs.next();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    public static int getRemainingDays(int slotIndex) {
+        cleanExpiredSlots();
+        if (connection == null) return 0;
+        String sql = "SELECT expires FROM slots WHERE slot_index = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, slotIndex);
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                long expires = rs.getLong("expires");
+                long diff = expires - System.currentTimeMillis();
+                return (int) Math.ceil(diff / 86400000.0);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public static void purchaseSlot(int slotIndex, int weeks, String playerName, Location loc) {
+        if (connection == null) return;
+        int shortcutId = createShortcut(playerName, "Tienda de " + playerName, loc);
+        if (shortcutId == -1) return;
+        long expires = System.currentTimeMillis() + weeks * 7L * 24L * 60L * 60L * 1000L;
+        String sql = "INSERT OR REPLACE INTO slots(slot_index, shortcut_id, expires) VALUES(?,?,?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, slotIndex);
+            ps.setInt(2, shortcutId);
+            ps.setLong(3, expires);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static List<Shortcut> getActiveShortcuts() {
+        cleanExpiredSlots();
+        List<Shortcut> list = new ArrayList<>();
+        if (connection == null) return list;
+        String sql = "SELECT sc.* FROM slots s JOIN shortcuts sc ON s.shortcut_id = sc.id WHERE s.expires > ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, System.currentTimeMillis());
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                Location loc = new Location(Bukkit.getWorld(rs.getString("world")),
+                        rs.getDouble("x"), rs.getDouble("y"), rs.getDouble("z"),
+                        rs.getFloat("yaw"), rs.getFloat("pitch"));
+                Shortcut sc = new Shortcut(
+                        rs.getInt("id"),
+                        rs.getString("name"),
+                        rs.getString("description"),
+                        loc);
+                list.add(sc);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
     }
 }

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
@@ -28,8 +28,6 @@ public class BuySlotGUI {
         int servStart = cfg.getInt("servidolar-slots.start");
         int servEnd = cfg.getInt("servidolar-slots.end");
 
-        // Ejemplo simple de ocupación: los dos primeros puestos de créditos ocupados
-
         int servSlotsPerPage = servEnd - servStart + 1;
 
         for (int slot = 0; slot < 26; slot++) {
@@ -42,7 +40,8 @@ public class BuySlotGUI {
                 priceIndex = slot + servSlotsPerPage * (page - 1);
             }
             double price = cfg.getDouble("slot-prices." + priceIndex, 0.0);
-            boolean ocupado = isCredit && (slot == creditStart || slot == creditStart + 1);
+            boolean ocupado = org.servicraft.servidirectorios.database.DatabaseManager.isSlotOccupied(priceIndex);
+            int remaining = org.servicraft.servidirectorios.database.DatabaseManager.getRemainingDays(priceIndex);
 
             int displayNumber = slot + 1;
             if (isServDisplay && page > 1) {
@@ -55,7 +54,7 @@ public class BuySlotGUI {
             List<String> lore = new ArrayList<>();
             if (ocupado) {
                 lore.add(ChatColor.GRAY + "Contrato expira en");
-                lore.add(ChatColor.GRAY + String.valueOf(slot == creditStart ? 9 : 2) + " días");
+                lore.add(ChatColor.GRAY + String.valueOf(remaining) + " días");
             } else {
                 lore.add(ChatColor.GRAY + "¡Haz clic para comprar");
                 lore.add(ChatColor.GRAY + "este puesto!");

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
@@ -16,11 +16,13 @@ public class BuySlotWeeksGUI {
     private static final Map<UUID, Integer> playerWeeks = new HashMap<>();
     private static final Map<UUID, Double> playerPrice = new HashMap<>();
     private static final Map<UUID, Boolean> playerCredit = new HashMap<>();
+    private static final Map<UUID, Integer> playerSlot = new HashMap<>();
 
-    public static void open(Player player, double price, boolean credit) {
+    public static void open(Player player, double price, boolean credit, int slotIndex) {
         playerWeeks.put(player.getUniqueId(), 1);
         playerPrice.put(player.getUniqueId(), price);
         playerCredit.put(player.getUniqueId(), credit);
+        playerSlot.put(player.getUniqueId(), slotIndex);
 
         Inventory inv = Bukkit.createInventory(null, 27, "Comprar puesto");
         inv.setItem(10, buildItem(Material.IRON_NUGGET, ChatColor.RED + "Reducir 1 semana", null));
@@ -111,5 +113,9 @@ public class BuySlotWeeksGUI {
 
     public static boolean isCredit(Player player) {
         return playerCredit.getOrDefault(player.getUniqueId(), false);
+    }
+
+    public static int getSlot(Player player) {
+        return playerSlot.getOrDefault(player.getUniqueId(), -1);
     }
 }

--- a/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class ShortcutMenu {
 
     public static void open(Player player) {
-        List<Shortcut> shortcuts = DatabaseManager.getShortcuts();
+        List<Shortcut> shortcuts = DatabaseManager.getActiveShortcuts();
         Inventory inv = Bukkit.createInventory(null, 27, "Directorios");
 
         int index = 0;

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotGUIListener.java
@@ -64,7 +64,7 @@ public class BuySlotGUIListener implements Listener {
                 double cost = cfg.getDouble("slot-prices." + priceIndex, 0.0);
                 boolean credit = slot >= creditStart && slot <= creditEnd;
 
-                BuySlotWeeksGUI.open(player, cost, credit);
+                BuySlotWeeksGUI.open(player, cost, credit, priceIndex);
             }
         }
     }

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
@@ -35,6 +35,7 @@ public class BuySlotWeeksGUIListener implements Listener {
             int weeks = BuySlotWeeksGUI.getWeeks(player);
             double price = BuySlotWeeksGUI.getPrice(player) * weeks;
             boolean credit = BuySlotWeeksGUI.isCredit(player);
+            int slotIndex = BuySlotWeeksGUI.getSlot(player);
             if (credit) {
                 player.sendMessage(ChatColor.GREEN + "Procesando compra con créditos...");
                 final Player target = player;
@@ -48,6 +49,7 @@ public class BuySlotWeeksGUIListener implements Listener {
                         success = false;
                     }
                     if (success) {
+                        org.servicraft.servidirectorios.database.DatabaseManager.purchaseSlot(slotIndex, weeks, target.getName(), target.getLocation());
                         org.bukkit.Bukkit.getScheduler().runTask(org.bukkit.Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> target.sendMessage(ChatColor.GREEN + "Compra exitosa."));
                     } else {
                         org.bukkit.Bukkit.getScheduler().runTask(org.bukkit.Bukkit.getPluginManager().getPlugin("servidirectorios"), () -> target.sendMessage(ChatColor.RED + "No tienes suficientes créditos o ocurrió un error."));
@@ -62,6 +64,7 @@ public class BuySlotWeeksGUIListener implements Listener {
                 if (econ.getBalance(player) >= price) {
                     net.milkbowl.vault.economy.EconomyResponse resp = econ.withdrawPlayer(player, price);
                     if (resp.transactionSuccess()) {
+                        org.servicraft.servidirectorios.database.DatabaseManager.purchaseSlot(slotIndex, weeks, player.getName(), player.getLocation());
                         player.sendMessage(ChatColor.GREEN + "Compra exitosa.");
                     } else {
                         player.sendMessage(ChatColor.RED + "No se pudo completar la transacción.");

--- a/src/main/java/org/servicraft/servidirectorios/listeners/ShortcutMenuListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/ShortcutMenuListener.java
@@ -24,7 +24,7 @@ public class ShortcutMenuListener implements Listener {
             if (meta == null || !meta.hasDisplayName()) return;
 
             String name = ChatColor.stripColor(meta.getDisplayName());
-            List<Shortcut> shortcuts = DatabaseManager.getShortcuts();
+            List<Shortcut> shortcuts = DatabaseManager.getActiveShortcuts();
             for (Shortcut sc : shortcuts) {
                 if (sc.getName().equalsIgnoreCase(name)) {
                     Player player = (Player) event.getWhoClicked();


### PR DESCRIPTION
## Summary
- store purchased slots in new database table
- mark slots as occupied in the buy GUI
- track slot info per player in weeks GUI
- save purchase details when confirming payment
- show only active slots in the directory menu
- fix H2 database URL to use an absolute path

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6841cb3d6468832f8ff2154ecf1c89c8