### PR TITLE
Corrige orden y alineación de los menús

### DIFF
--- a/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
+++ b/src/main/java/org/servicraft/servidirectorios/database/DatabaseManager.java
@@ -202,10 +202,15 @@ public class DatabaseManager {
     }
 
     public static List<Shortcut> getActiveShortcuts() {
+        return new ArrayList<>(getActiveShortcutMap().values());
+    }
+
+    public static java.util.Map<Integer, Shortcut> getActiveShortcutMap() {
         cleanExpiredSlots();
-        List<Shortcut> list = new ArrayList<>();
-        if (connection == null) return list;
-        String sql = "SELECT sc.* FROM slots s JOIN shortcuts sc ON s.shortcut_id = sc.id WHERE s.expires > ?";
+        java.util.Map<Integer, Shortcut> map = new java.util.LinkedHashMap<>();
+        if (connection == null) return map;
+        String sql = "SELECT s.slot_index, sc.* FROM slots s JOIN shortcuts sc ON s.shortcut_id = sc.id " +
+                "WHERE s.expires > ? ORDER BY s.slot_index";
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setLong(1, System.currentTimeMillis());
             ResultSet rs = ps.executeQuery();
@@ -218,11 +223,11 @@ public class DatabaseManager {
                         rs.getString("name"),
                         rs.getString("description"),
                         loc);
-                list.add(sc);
+                map.put(rs.getInt("slot_index"), sc);
             }
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return list;
+        return map;
     }
 }

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotGUI.java
@@ -66,7 +66,7 @@ public class BuySlotGUI {
                 lore.add(ChatColor.AQUA + formatted + " créditos");
             } else {
                 String formatted = java.text.NumberFormat.getInstance(java.util.Locale.GERMAN).format(price);
-                lore.add(ChatColor.GREEN + "$" + formatted + "servi" + ChatColor.DARK_GREEN + "dólares");
+                lore.add(ChatColor.GREEN + "$" + formatted + " servi" + ChatColor.DARK_GREEN + "dólares");
             }
 
             inv.setItem(slot, buildItem(mat, nombre, lore));

--- a/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/BuySlotWeeksGUI.java
@@ -25,9 +25,9 @@ public class BuySlotWeeksGUI {
         playerSlot.put(player.getUniqueId(), slotIndex);
 
         Inventory inv = Bukkit.createInventory(null, 27, "Comprar puesto");
-        inv.setItem(10, buildItem(Material.IRON_NUGGET, ChatColor.RED + "Reducir 1 semana", null));
-        inv.setItem(12, buildPayItem(player));
-        inv.setItem(14, buildItem(Material.GOLD_NUGGET, ChatColor.GREEN + "Incrementar una semana", null));
+        inv.setItem(9, buildItem(Material.IRON_NUGGET, ChatColor.RED + "Reducir 1 semana", null));
+        inv.setItem(11, buildPayItem(player));
+        inv.setItem(13, buildItem(Material.GOLD_NUGGET, ChatColor.GREEN + "Incrementar una semana", null));
 
         fillEmptySlots(inv, Material.BLACK_STAINED_GLASS_PANE, " ");
 

--- a/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
+++ b/src/main/java/org/servicraft/servidirectorios/gui/ShortcutMenu.java
@@ -15,12 +15,13 @@ import java.util.List;
 public class ShortcutMenu {
 
     public static void open(Player player) {
-        List<Shortcut> shortcuts = DatabaseManager.getActiveShortcuts();
+        java.util.Map<Integer, Shortcut> shortcuts = DatabaseManager.getActiveShortcutMap();
         Inventory inv = Bukkit.createInventory(null, 27, "Directorios");
 
-        int index = 0;
-        for (Shortcut sc : shortcuts) {
-            if (index >= inv.getSize()) break;
+        for (java.util.Map.Entry<Integer, Shortcut> entry : shortcuts.entrySet()) {
+            int slot = entry.getKey();
+            if (slot >= inv.getSize()) continue;
+            Shortcut sc = entry.getValue();
             ItemStack item = new ItemStack(Material.CHEST);
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
@@ -28,8 +29,7 @@ public class ShortcutMenu {
                 meta.setLore(java.util.Arrays.asList(ChatColor.GRAY + sc.getDescription()));
                 item.setItemMeta(meta);
             }
-            inv.setItem(index, item);
-            index++;
+            inv.setItem(slot, item);
         }
 
         // fill rest with decorative glass

--- a/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/BuySlotWeeksGUIListener.java
@@ -27,11 +27,11 @@ public class BuySlotWeeksGUIListener implements Listener {
         Player player = (Player) event.getWhoClicked();
         Inventory inv = event.getInventory();
         int slot = event.getRawSlot();
-        if (slot == 10) {
+        if (slot == 9) {
             BuySlotWeeksGUI.decrementWeeks(player, inv);
-        } else if (slot == 14) {
+        } else if (slot == 13) {
             BuySlotWeeksGUI.incrementWeeks(player, inv);
-        } else if (slot == 12) {
+        } else if (slot == 11) {
             int weeks = BuySlotWeeksGUI.getWeeks(player);
             double price = BuySlotWeeksGUI.getPrice(player) * weeks;
             boolean credit = BuySlotWeeksGUI.isCredit(player);

--- a/src/main/java/org/servicraft/servidirectorios/listeners/ShortcutMenuListener.java
+++ b/src/main/java/org/servicraft/servidirectorios/listeners/ShortcutMenuListener.java
@@ -24,8 +24,8 @@ public class ShortcutMenuListener implements Listener {
             if (meta == null || !meta.hasDisplayName()) return;
 
             String name = ChatColor.stripColor(meta.getDisplayName());
-            List<Shortcut> shortcuts = DatabaseManager.getActiveShortcuts();
-            for (Shortcut sc : shortcuts) {
+            java.util.Map<Integer, Shortcut> shortcuts = DatabaseManager.getActiveShortcutMap();
+            for (Shortcut sc : shortcuts.values()) {
                 if (sc.getName().equalsIgnoreCase(name)) {
                     Player player = (Player) event.getWhoClicked();
                     player.closeInventory();


### PR DESCRIPTION
## Summary
- preserva el orden de compra de los puestos utilizando `slot_index`
- coloca cada puesto en su slot correspondiente en `/directorios`
- corrige la posición de los botones en la GUI de compra por semanas
- ajusta los slots escuchados por el listener correspondiente
- añade espacio faltante en el precio en servidólares

## Testing
- `gradle classes`

------
https://chatgpt.com/codex/tasks/task_e_6841d4d32b68832f8c80cc7e0a6f7db9